### PR TITLE
Make size_gb an integer

### DIFF
--- a/add_key_pair_body.go
+++ b/add_key_pair_body.go
@@ -11,7 +11,7 @@
 package gsclientgen
 
 type AddKeyPairBody struct {
-	Description string `json:"description,omitempty"`
+	Description string `json:"description"`
 
 	TtlHours int32 `json:"ttl_hours,omitempty"`
 }

--- a/add_key_pair_response_model.go
+++ b/add_key_pair_response_model.go
@@ -11,9 +11,9 @@
 package gsclientgen
 
 type AddKeyPairResponseModel struct {
-	StatusCode int32 `json:"status_code,omitempty"`
+	StatusCode int32 `json:"status_code"`
 
-	StatusText string `json:"status_text,omitempty"`
+	StatusText string `json:"status_text"`
 
 	Data AddKeyPairResponseModelData `json:"data,omitempty"`
 }

--- a/add_key_pair_response_model_data.go
+++ b/add_key_pair_response_model_data.go
@@ -11,7 +11,7 @@
 package gsclientgen
 
 type AddKeyPairResponseModelData struct {
-	Id string `json:"id,omitempty"`
+	Id string `json:"id"`
 
 	Description string `json:"description,omitempty"`
 

--- a/api-spec/oai-spec.yaml
+++ b/api-spec/oai-spec.yaml
@@ -364,15 +364,13 @@ definitions:
         type: object
         properties:
           size_gb:
-            # TODO: change to integer
-            type: string
+            type: integer
             description: RAM size in GB
       storage:
         type: object
         properties:
           size_gb:
-            # TODO: change to integer
-            type: string
+            type: integer
             description: Node storage size in GB
       cpu:
         type: object

--- a/api_client.go
+++ b/api_client.go
@@ -89,17 +89,20 @@ func (c *APIClient) CallAPI(path string, method string,
 }
 
 func (c *APIClient) ParameterToString(obj interface{}, collectionFormat string) string {
-	if reflect.TypeOf(obj).String() == "[]string" {
-		switch collectionFormat {
-		case "pipes":
-			return strings.Join(obj.([]string), "|")
-		case "ssv":
-			return strings.Join(obj.([]string), " ")
-		case "tsv":
-			return strings.Join(obj.([]string), "\t")
-		case "csv":
-			return strings.Join(obj.([]string), ",")
-		}
+	delimiter := ""
+	switch collectionFormat {
+	case "pipes":
+		delimiter = "|"
+	case "ssv":
+		delimiter = " "
+	case "tsv":
+		delimiter = "\t"
+	case "csv":
+		delimiter = ","
+	}
+
+	if reflect.TypeOf(obj).Kind() == reflect.Slice {
+		return strings.Trim(strings.Replace(fmt.Sprint(obj), " ", delimiter, -1), "[]")
 	}
 
 	return fmt.Sprintf("%v", obj)

--- a/cluster_model.go
+++ b/cluster_model.go
@@ -11,7 +11,7 @@
 package gsclientgen
 
 type ClusterModel struct {
-	Id string `json:"id,omitempty"`
+	Id string `json:"id"`
 
 	Name string `json:"name,omitempty"`
 

--- a/configuration.go
+++ b/configuration.go
@@ -17,7 +17,7 @@ import (
 )
 
 type Configuration struct {
-	UserName      string            `json:"userName,omitempty"`
+	Username      string            `json:"userName,omitempty"`
 	Password      string            `json:"password,omitempty"`
 	APIKeyPrefix  map[string]string `json:"APIKeyPrefix,omitempty"`
 	APIKey        map[string]string `json:"APIKey,omitempty"`
@@ -50,7 +50,7 @@ func NewConfiguration() *Configuration {
 }
 
 func (c *Configuration) GetBasicAuthEncodedString() string {
-	return base64.StdEncoding.EncodeToString([]byte(c.UserName + ":" + c.Password))
+	return base64.StdEncoding.EncodeToString([]byte(c.Username + ":" + c.Password))
 }
 
 func (c *Configuration) AddDefaultHeader(key string, value string) {

--- a/docs/V4NodeDefinitionModelMemory.md
+++ b/docs/V4NodeDefinitionModelMemory.md
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**SizeGb** | **string** | RAM size in GB | [optional] [default to null]
+**SizeGb** | **int32** | RAM size in GB | [optional] [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/docs/V4NodeDefinitionModelStorage.md
+++ b/docs/V4NodeDefinitionModelStorage.md
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**SizeGb** | **string** | Node storage size in GB | [optional] [default to null]
+**SizeGb** | **int32** | Node storage size in GB | [optional] [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/generic_response_model.go
+++ b/generic_response_model.go
@@ -11,7 +11,7 @@
 package gsclientgen
 
 type GenericResponseModel struct {
-	StatusCode int32 `json:"status_code,omitempty"`
+	StatusCode int32 `json:"status_code"`
 
-	StatusText string `json:"status_text,omitempty"`
+	StatusText string `json:"status_text"`
 }

--- a/key_pair_model.go
+++ b/key_pair_model.go
@@ -11,11 +11,11 @@
 package gsclientgen
 
 type KeyPairModel struct {
-	Id string `json:"id,omitempty"`
+	Id string `json:"id"`
 
-	Description string `json:"description,omitempty"`
+	Description string `json:"description"`
 
-	TtlHours int32 `json:"ttl_hours,omitempty"`
+	TtlHours int32 `json:"ttl_hours"`
 
 	CreateDate string `json:"create_date,omitempty"`
 

--- a/key_pairs_response_model.go
+++ b/key_pairs_response_model.go
@@ -13,7 +13,7 @@ package gsclientgen
 type KeyPairsResponseModel struct {
 	Data KeyPairsResponseModelData `json:"data,omitempty"`
 
-	StatusCode int32 `json:"status_code,omitempty"`
+	StatusCode int32 `json:"status_code"`
 
-	StatusText string `json:"status_text,omitempty"`
+	StatusText string `json:"status_text"`
 }

--- a/login_body_model.go
+++ b/login_body_model.go
@@ -13,5 +13,5 @@ package gsclientgen
 type LoginBodyModel struct {
 
 	// base64 encoded password
-	Password string `json:"password,omitempty"`
+	Password string `json:"password"`
 }

--- a/login_response_model.go
+++ b/login_response_model.go
@@ -13,7 +13,7 @@ package gsclientgen
 type LoginResponseModel struct {
 	Data LoginResponseModelData `json:"data,omitempty"`
 
-	StatusCode int32 `json:"status_code,omitempty"`
+	StatusCode int32 `json:"status_code"`
 
-	StatusText string `json:"status_text,omitempty"`
+	StatusText string `json:"status_text"`
 }

--- a/login_response_model_data.go
+++ b/login_response_model_data.go
@@ -13,5 +13,5 @@ package gsclientgen
 type LoginResponseModelData struct {
 
 	// New session token
-	Id string `json:"Id,omitempty"`
+	Id string `json:"Id"`
 }

--- a/organization_clusters_response_model.go
+++ b/organization_clusters_response_model.go
@@ -13,7 +13,7 @@ package gsclientgen
 type OrganizationClustersResponseModel struct {
 	Data OrganizationClustersResponseModelData `json:"data,omitempty"`
 
-	StatusCode int32 `json:"status_code,omitempty"`
+	StatusCode int32 `json:"status_code"`
 
-	StatusText string `json:"status_text,omitempty"`
+	StatusText string `json:"status_text"`
 }

--- a/user_organizations_response_model.go
+++ b/user_organizations_response_model.go
@@ -11,9 +11,9 @@
 package gsclientgen
 
 type UserOrganizationsResponseModel struct {
-	Data []string `json:"data,omitempty"`
+	Data []string `json:"data"`
 
-	StatusCode int32 `json:"status_code,omitempty"`
+	StatusCode int32 `json:"status_code"`
 
-	StatusText string `json:"status_text,omitempty"`
+	StatusText string `json:"status_text"`
 }

--- a/v4_cluster_details_model.go
+++ b/v4_cluster_details_model.go
@@ -11,7 +11,7 @@
 package gsclientgen
 
 type V4ClusterDetailsModel struct {
-	Id string `json:"id,omitempty"`
+	Id string `json:"id"`
 
 	Name string `json:"name,omitempty"`
 

--- a/v4_generic_response_model.go
+++ b/v4_generic_response_model.go
@@ -11,7 +11,7 @@
 package gsclientgen
 
 type V4GenericResponseModel struct {
-	Code string `json:"code,omitempty"`
+	Code string `json:"code"`
 
-	Message string `json:"message,omitempty"`
+	Message string `json:"message"`
 }

--- a/v4_node_definition_model_memory.go
+++ b/v4_node_definition_model_memory.go
@@ -13,5 +13,5 @@ package gsclientgen
 type V4NodeDefinitionModelMemory struct {
 
 	// RAM size in GB
-	SizeGb string `json:"size_gb,omitempty"`
+	SizeGb int32 `json:"size_gb,omitempty"`
 }

--- a/v4_node_definition_model_storage.go
+++ b/v4_node_definition_model_storage.go
@@ -13,5 +13,5 @@ package gsclientgen
 type V4NodeDefinitionModelStorage struct {
 
 	// Node storage size in GB
-	SizeGb string `json:"size_gb,omitempty"`
+	SizeGb int32 `json:"size_gb,omitempty"`
 }


### PR DESCRIPTION
This change is required to let `gsctl` talk to the API on g8s again and fetch cluster details/create clusters, as the according change there is already deployed.

Related to https://github.com/giantswarm/gsctl/issues/26