### PR TITLE
Use latest swagger-codegen-cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ generate: clean
 	docker run --rm -it \
 		-v ${PWD}:/swagger-api/out \
 		-v ${PWD}/api-spec:/swagger-api/yaml \
-		jimschubert/swagger-codegen-cli:gsclientgen generate \
+		jimschubert/swagger-codegen-cli:2.2.3 generate \
 		--input-spec /swagger-api/yaml/oai-spec.yaml \
 		--lang go \
 		--config /swagger-api/out/swagger-codegen-conf.json \

--- a/api_client.go
+++ b/api_client.go
@@ -13,7 +13,7 @@ package gsclientgen
 import (
 	"bytes"
 	"fmt"
-	"github.com/go-resty/resty"
+	"gopkg.in/go-resty/resty.v0"
 	"io/ioutil"
 	"net/url"
 	"path/filepath"


### PR DESCRIPTION
This pins the swagger-codegen-cli version to 2.2.3, to use an image that is actually available for all of us.

The resulting change in generated code is marginal.